### PR TITLE
Add an APK build phase to extract-code-for-mastg-demo.sh

### DIFF
--- a/tools/extract-code-for-mastg-demo.sh
+++ b/tools/extract-code-for-mastg-demo.sh
@@ -9,6 +9,9 @@ APK_PATH="./app/build/outputs/apk/debug/app-debug.apk"
 # Create a temporary directory for jadx output
 TEMP_JADX_OUTPUT_DIR="$OUTPUT_DIR/temp_jadx_output"
 
+# Build Android Studio project
+gradle assembleDebug
+
 # Create temporary directories for output
 mkdir -p "$OUTPUT_DIR"
 mkdir -p "$TEMP_APKTOOL_DIR"


### PR DESCRIPTION
I added a phase to build the Android Studio project with a `gradle` command. It's useful because it ensures that the output APK always contains the most recent `MastgTest.kt`.