### PR TITLE
Add new // ADD_ANDROID_HERE placeholder inside the android block

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    // ADD_ANDROID_HERE
 }
 
 // ADD_SECTIONS_HERE


### PR DESCRIPTION
This PR makes a very small change to the `app/build.gradle.kts` file, adding a placeholder comment `// ADD_ANDROID_HERE` within the `android` block to support e.g. ndk libs